### PR TITLE
ci: add smoke workflow for node-setup action

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,13 @@
+name: Smoke
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: p6m7g8-actions/checkout@main
+      - name: Run node-setup action
+        uses: ./


### PR DESCRIPTION
## Summary
- add local smoke workflow for node-setup composite action
- use p6m7g8-actions/checkout@main for checkout in smoke job

## Testing
- p6_github_cli_act -W .github/workflows/smoke.yml -j smoke